### PR TITLE
Modified predicate for activating checkers so that it can fallback to…

### DIFF
--- a/flycheck-joker.el
+++ b/flycheck-joker.el
@@ -58,7 +58,13 @@
   ((error line-start "<stdin>:" line ":" column ": " (0+ not-newline) (or "error: " "Exception: ") (message) line-end)
    (warning line-start "<stdin>:" line ":" column ": " (0+ not-newline) "warning: " (message) line-end))
   :modes (clojure-mode clojurec-mode)
-  :predicate (lambda () (not (string= "edn" (file-name-extension (buffer-file-name))))))
+  :predicate (lambda ()
+               (let (buffer-file-name (buffer-file-name))
+                 (if buffer-file-name
+                     (not (string= "edn" (file-name-extension buffer-file-name)))
+                   (when (or (equal 'clojure-mode major-mode)
+                             (equal 'clojurec-mode major-mode))
+                     t)))))
 
 (flycheck-define-checker clojurescript-joker
   "A ClojureScript syntax checker using Joker.
@@ -80,7 +86,10 @@
   ((error line-start "<stdin>:" line ":" column ": " (0+ not-newline) (or "error: " "Exception: ") (message) line-end)
    (warning line-start "<stdin>:" line ":" column ": " (0+ not-newline) "warning: " (message) line-end))
   :modes (clojure-mode clojurec-mode)
-  :predicate (lambda () (string= "edn" (file-name-extension (buffer-file-name)))))
+  :predicate (lambda ()
+               (let (buffer-file-name (buffer-file-name))
+                 (when buffer-file-name
+                   (string= "edn" (file-name-extension buffer-file-name))))))
 
 (add-to-list 'flycheck-checkers 'clojure-joker)
 (add-to-list 'flycheck-checkers 'clojurescript-joker)


### PR DESCRIPTION
… using the major mode when there are no associated files with the Clojure buffer.

Also fixed an issue with the edn predicate, where it would throw a stringp error when called from a buffer without a file due to buffer-file-name being nil.

This allows flycheck-joker to be enabled and linting buffers that don't have a file associated with them. I often create buffers with no files and start a REPL just to mess and around, and I was missing having joker available in them.

I tested the following combination on my desktop:
* clojure-mode no file
* clojurec-mode no file
* clojurescript-mode no file
* clojure-mode with file
* clojurec-mode with file
* clojurescript-mode with file