### PR TITLE
Fixed a bug where edn linter would not turn on when working with edn …

### DIFF
--- a/flycheck-joker.el
+++ b/flycheck-joker.el
@@ -59,7 +59,7 @@
    (warning line-start "<stdin>:" line ":" column ": " (0+ not-newline) "warning: " (message) line-end))
   :modes (clojure-mode clojurec-mode)
   :predicate (lambda ()
-               (let (buffer-file-name (buffer-file-name))
+               (let ((buffer-file-name (buffer-file-name)))
                  (if buffer-file-name
                      (not (string= "edn" (file-name-extension buffer-file-name)))
                    (when (or (equal 'clojure-mode major-mode)
@@ -87,7 +87,7 @@
    (warning line-start "<stdin>:" line ":" column ": " (0+ not-newline) "warning: " (message) line-end))
   :modes (clojure-mode clojurec-mode)
   :predicate (lambda ()
-               (let (buffer-file-name (buffer-file-name))
+               (let ((buffer-file-name (buffer-file-name)))
                  (when buffer-file-name
                    (string= "edn" (file-name-extension buffer-file-name))))))
 


### PR DESCRIPTION
…file, due to forgetting to wrap let binding in extra parenthesis.

I introduced a bug in: https://github.com/candid82/flycheck-joker/pull/4 and this fixes it.

Sorry about that, realized I had forgot to test with an `.edn` file, and that made me realize I had a stupid bug that made `buffer-file-name` always nil, because I wasn't using `let` properly.